### PR TITLE
Miscellaneous fixes

### DIFF
--- a/mpvi.el
+++ b/mpvi.el
@@ -410,16 +410,19 @@ When NOSEEK is not nil then dont try to seek but open directly."
   "Build mpv link with timestamp that used in org buffer.
 PATH is local video file or remote url. BEG and END is the position number.
 DESC is optional, used to describe the current timestamp link."
-  (concat "[[mpv:" path (if (or beg end) "#")
-          (if beg (number-to-string beg))
-          (if end "-")
-          (if end (number-to-string end))
-          "][▶ "
-          (if beg (mpvi-secs-to-hms beg nil t))
-          (if end " → ")
-          (if end (mpvi-secs-to-hms end nil t))
-          "]]"
-          (if desc (concat " " desc))))
+  (concat
+   (org-link-make-string
+    (concat
+     "mpv:" path (if (or beg end) "#")
+     (if beg (number-to-string beg))
+     (if end "-")
+     (if end (number-to-string end)))
+    (concat
+     "▶ "
+     (if beg (mpvi-secs-to-hms beg nil t))
+     (if end " → ")
+     (if end (mpvi-secs-to-hms end nil t))))
+   (if desc (concat " " desc))))
 
 (defcustom mpvi-attach-link-attrs "#+attr_html: :width 666"
   "Attrs insert above a inserted attach image.
@@ -435,7 +438,7 @@ The :width can make image cannot display too large in org mode."
   (when mpvi-attach-link-attrs
     (insert (string-trim mpvi-attach-link-attrs) "\n"))
   ;; insert the link
-  (insert "[[attachment:" (file-name-base file) "." (file-name-extension file) "]]")
+  (insert (org-link-make-string (concat "attachment:" (file-name-nondirectory file))))
   ;; show it
   (org-display-inline-images))
 

--- a/mpvi.el
+++ b/mpvi.el
@@ -158,7 +158,7 @@ When GROUPP not nil then try to insert commas to string for better reading."
 (defun mpvi-mpv-version ()
   "Return the current mpv version as a cons cell."
   (with-temp-buffer
-    (process-file "mpv" nil t "--version")
+    (process-file "mpv" nil t nil "--version")
     (goto-char (point-min))
     (if (re-search-forward "v\\([0-9]+\\)\\.\\([0-9]+\\)" (line-end-position) t)
         (cons (string-to-number (match-string 1))


### PR DESCRIPTION
1. Fixed the incorrect `args` parameter passed to `process-file` (where `--version` was treated as parameter `display`), although the current version happens to work because `mpv` outputs version information by default in the GUI's absence. 2. Fixed malformed Org links inserted for files whose names contain `[` or `]`.